### PR TITLE
Fixing Enrollments secid Query String

### DIFF
--- a/app/routes/enrollments.js
+++ b/app/routes/enrollments.js
@@ -78,7 +78,7 @@ router.route('/v1/enrollments')
       var queryTwo = Enrollment.find({ id: { $in: qString.ids } });
     } else if (qString.secid) {
       var queryOne = Enrollment.find({ sectionId: qString.secid });
-      var queryOne = Enrollment.find({ sectionId: qString.secid });
+      var queryTwo = Enrollment.find({ sectionId: qString.secid });
     } else if (qString.stunum) {
       var queryOne = Enrollment.find({ studentNumber: qString.stunum });
       var queryTwo = Enrollment.find({ studentNumber: qString.stunum });


### PR DESCRIPTION
Previously, there had been a duplicate of a variable. Comparing it with
the other query strings, this was an error; so I simply replaced the
duplicate ‘queryOne’ variable with ‘queryTwo’.