### PR TITLE
Basic Permissions based on user's user_type attribute

### DIFF
--- a/app/routes/computers.js
+++ b/app/routes/computers.js
@@ -29,6 +29,10 @@ router.route('/v1/computers')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Computer.findOne({serialNumber: req.body.computer.serialNumber}, function (err, sct) {
       if (sct) {
         var now = new Date().getTime();
@@ -148,6 +152,10 @@ router.route('/v1/computers/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var now = new Date().getTime();
     req.body.computer.updatedAt = now;
     Computer.findOneAndUpdate({id: req.params.id}, {$set: req.body.computer}, function(err,computer) {
@@ -170,6 +178,10 @@ router.route('/v1/computers/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Computer.remove({id: req.params.id}, function(err, computer) {
       if (err)
         res.send(err);

--- a/app/routes/computers.js
+++ b/app/routes/computers.js
@@ -8,10 +8,11 @@ var passport = require('passport');
 router.route('/v1/computers')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
-    console.log('where is my stuff');
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var computer = new Computer(req.body.computer);
-    console.log("data should be next");
-    console.log(computer);
     computer.save(function (err, obj) {
       if(err) 
         res.send(err);

--- a/app/routes/computers.js
+++ b/app/routes/computers.js
@@ -8,10 +8,6 @@ var passport = require('passport');
 router.route('/v1/computers')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var computer = new Computer(req.body.computer);
     computer.save(function (err, obj) {
       if(err) 
@@ -29,10 +25,6 @@ router.route('/v1/computers')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Computer.findOne({serialNumber: req.body.computer.serialNumber}, function (err, sct) {
       if (sct) {
         var now = new Date().getTime();
@@ -152,10 +144,6 @@ router.route('/v1/computers/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var now = new Date().getTime();
     req.body.computer.updatedAt = now;
     Computer.findOneAndUpdate({id: req.params.id}, {$set: req.body.computer}, function(err,computer) {
@@ -178,10 +166,6 @@ router.route('/v1/computers/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Computer.remove({id: req.params.id}, function(err, computer) {
       if (err)
         res.send(err);

--- a/app/routes/computers.js
+++ b/app/routes/computers.js
@@ -7,7 +7,7 @@ var passport = require('passport');
 
 router.route('/v1/computers')
 
-  .post(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .post(function(req, res) {
     var computer = new Computer(req.body.computer);
     computer.save(function (err, obj) {
       if(err) 
@@ -24,7 +24,7 @@ router.route('/v1/computers')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     Computer.findOne({serialNumber: req.body.computer.serialNumber}, function (err, sct) {
       if (sct) {
         var now = new Date().getTime();
@@ -65,7 +65,7 @@ router.route('/v1/computers')
     });
   })
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     var qString = req.query;
     if (qString.ids) {
       var queryOne = Computer.find({ id: { $in: qString.ids } });
@@ -123,7 +123,7 @@ router.route('/v1/computers')
 
 router.route('/v1/computers/:id')
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     Computer.findOne({id: req.params.id}, function(err, obj) {
       if (err)
         res.send(err);
@@ -143,7 +143,7 @@ router.route('/v1/computers/:id')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     var now = new Date().getTime();
     req.body.computer.updatedAt = now;
     Computer.findOneAndUpdate({id: req.params.id}, {$set: req.body.computer}, function(err,computer) {
@@ -165,7 +165,7 @@ router.route('/v1/computers/:id')
     });
   })
 
-  .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .delete(function(req, res) {
     Computer.remove({id: req.params.id}, function(err, computer) {
       if (err)
         res.send(err);

--- a/app/routes/employees.js
+++ b/app/routes/employees.js
@@ -118,7 +118,7 @@ router.route('/v1/employees')
             callback(null, items);
           });
         } else {
-          queryTwo.skip(offset).select('-_id id firstName lastName buildingName username title').limit(limit).exec('find', function(err, items) {
+          queryTwo.skip(offset).select('-_id id firstName lastName buildingName buildingStateCode username title').limit(limit).exec('find', function(err, items) {
             callback(null, items);
           });
         }

--- a/app/routes/employees.js
+++ b/app/routes/employees.js
@@ -24,7 +24,7 @@ router.route('/v1/employees')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     Employee.findOne({nameId: req.body.employee.nameId}, function (err, emp) {
       if (emp) {
         if (emp.nalphakey == req.body.employee.nalphakey && emp.firstName == req.body.employee.firstName 
@@ -75,7 +75,7 @@ router.route('/v1/employees')
     });
   })
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     var qString = req.query;
     if (qString.ids) {
       var queryOne = Employee.find({ id: { $in: qString.ids } });
@@ -171,7 +171,7 @@ router.route('/v1/employees/:id')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     var now = new Date().getTime();
     req.body.employee.updatedAt = now;
     Employee.findOneAndUpdate({id: req.params.id}, {$set: req.body.employee}, function(err,employee) {
@@ -193,7 +193,7 @@ router.route('/v1/employees/:id')
     });
   })
 
-  .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .delete(function(req, res) {
     Employee.remove({id: req.params.id}, function(err, employee) {
       if (err)
         res.send(err);

--- a/app/routes/employees.js
+++ b/app/routes/employees.js
@@ -7,11 +7,7 @@ var passport = require('passport');
 
 router.route('/v1/employees')
 
-  .post(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
+  .post(function(req, res) {
     var employee = new Employee(req.body.employee);
     employee.save(function (err, obj) {
       if(err) 
@@ -29,10 +25,6 @@ router.route('/v1/employees')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Employee.findOne({nameId: req.body.employee.nameId}, function (err, emp) {
       if (emp) {
         if (emp.nalphakey == req.body.employee.nalphakey && emp.firstName == req.body.employee.firstName 
@@ -149,7 +141,7 @@ router.route('/v1/employees')
   })
 
 router.route('/v1/employees/:id')
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     Employee.findOne({id: req.params.id}, function(err, obj) {
       if (err)
         res.send(err);
@@ -180,10 +172,6 @@ router.route('/v1/employees/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var now = new Date().getTime();
     req.body.employee.updatedAt = now;
     Employee.findOneAndUpdate({id: req.params.id}, {$set: req.body.employee}, function(err,employee) {
@@ -206,10 +194,6 @@ router.route('/v1/employees/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Employee.remove({id: req.params.id}, function(err, employee) {
       if (err)
         res.send(err);

--- a/app/routes/enrollments.js
+++ b/app/routes/enrollments.js
@@ -8,6 +8,10 @@ var passport = require('passport');
 router.route('/v1/enrollments')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var enrollment = new Enrollment(req.body.enrollment);
     enrollment.save(function (err, obj) {
       if(err) 
@@ -25,6 +29,10 @@ router.route('/v1/enrollments')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Enrollment.findOne({psId: req.body.enrollment.psId}, function (err, erm) {
       if (erm) {
         if (erm.studentNumber == req.body.enrollment.studentNumber && erm.sectionId == req.body.enrollment.sectionId) {
@@ -72,6 +80,10 @@ router.route('/v1/enrollments')
   })
 
   .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var qString = req.query;
     if (qString.ids) {
       var queryOne = Enrollment.find({ id: { $in: qString.ids } });
@@ -130,6 +142,10 @@ router.route('/v1/enrollments')
 router.route('/v1/enrollments/:id')
 
   .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Enrollment.findOne({id: req.params.id}, function(err, obj) {
       if (err)
         res.send(err);
@@ -150,6 +166,10 @@ router.route('/v1/enrollments/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var now = new Date().getTime();
     req.body.enrollment.updatedAt = now;
     Enrollment.findOneAndUpdate({id: req.params.id}, {$set: req.body.enrollment}, function(err,enrollment) {
@@ -172,6 +192,10 @@ router.route('/v1/enrollments/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Enrollment.remove({id: req.params.id}, function(err, enrollment) {
       if (err)
         res.send(err);

--- a/app/routes/enrollments.js
+++ b/app/routes/enrollments.js
@@ -8,10 +8,6 @@ var passport = require('passport');
 router.route('/v1/enrollments')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var enrollment = new Enrollment(req.body.enrollment);
     enrollment.save(function (err, obj) {
       if(err) 
@@ -29,10 +25,6 @@ router.route('/v1/enrollments')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Enrollment.findOne({psId: req.body.enrollment.psId}, function (err, erm) {
       if (erm) {
         if (erm.studentNumber == req.body.enrollment.studentNumber && erm.sectionId == req.body.enrollment.sectionId) {
@@ -166,10 +158,6 @@ router.route('/v1/enrollments/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var now = new Date().getTime();
     req.body.enrollment.updatedAt = now;
     Enrollment.findOneAndUpdate({id: req.params.id}, {$set: req.body.enrollment}, function(err,enrollment) {
@@ -192,10 +180,6 @@ router.route('/v1/enrollments/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Enrollment.remove({id: req.params.id}, function(err, enrollment) {
       if (err)
         res.send(err);

--- a/app/routes/enrollments.js
+++ b/app/routes/enrollments.js
@@ -7,7 +7,7 @@ var passport = require('passport');
 
 router.route('/v1/enrollments')
 
-  .post(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .post(function(req, res) {
     var enrollment = new Enrollment(req.body.enrollment);
     enrollment.save(function (err, obj) {
       if(err) 
@@ -24,7 +24,7 @@ router.route('/v1/enrollments')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     Enrollment.findOne({psId: req.body.enrollment.psId}, function (err, erm) {
       if (erm) {
         if (erm.studentNumber == req.body.enrollment.studentNumber && erm.sectionId == req.body.enrollment.sectionId) {
@@ -71,7 +71,7 @@ router.route('/v1/enrollments')
     });
   })
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     if(req.user.user_type != "Administrator") {
       res.send(403,JSON.stringify({"error": "insufficientPermission"}));
       return;
@@ -133,7 +133,7 @@ router.route('/v1/enrollments')
 
 router.route('/v1/enrollments/:id')
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     if(req.user.user_type != "Administrator") {
       res.send(403,JSON.stringify({"error": "insufficientPermission"}));
       return;
@@ -157,7 +157,7 @@ router.route('/v1/enrollments/:id')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     var now = new Date().getTime();
     req.body.enrollment.updatedAt = now;
     Enrollment.findOneAndUpdate({id: req.params.id}, {$set: req.body.enrollment}, function(err,enrollment) {
@@ -179,7 +179,7 @@ router.route('/v1/enrollments/:id')
     });
   })
 
-  .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .delete(function(req, res) {
     Enrollment.remove({id: req.params.id}, function(err, enrollment) {
       if (err)
         res.send(err);

--- a/app/routes/sections.js
+++ b/app/routes/sections.js
@@ -8,10 +8,6 @@ var passport = require('passport');
 router.route('/v1/sections')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var section = new Section(req.body.section);
     section.save(function (err, obj) {
       if(err) 
@@ -29,10 +25,6 @@ router.route('/v1/sections')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Section.findOne({psId: req.body.section.psId}, function (err, sct) {
       if (sct) {
         if (sct.expression == req.body.section.expression && sct.studentCount == req.body.section.studentCount 
@@ -172,10 +164,6 @@ router.route('/v1/sections/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var now = new Date().getTime();
     req.body.section.updatedAt = now;
     Section.findOneAndUpdate({id: req.params.id}, {$set: req.body.section}, function(err,section) {
@@ -198,10 +186,6 @@ router.route('/v1/sections/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Section.remove({id: req.params.id}, function(err, section) {
       if (err)
         res.send(err);

--- a/app/routes/sections.js
+++ b/app/routes/sections.js
@@ -8,6 +8,10 @@ var passport = require('passport');
 router.route('/v1/sections')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var section = new Section(req.body.section);
     section.save(function (err, obj) {
       if(err) 
@@ -25,6 +29,10 @@ router.route('/v1/sections')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Section.findOne({psId: req.body.section.psId}, function (err, sct) {
       if (sct) {
         if (sct.expression == req.body.section.expression && sct.studentCount == req.body.section.studentCount 
@@ -73,6 +81,10 @@ router.route('/v1/sections')
   })
 
   .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var qString = req.query;
     if (qString.ids) {
       var queryOne = Section.find({ id: { $in: qString.ids } });
@@ -136,6 +148,10 @@ router.route('/v1/sections')
 router.route('/v1/sections/:id')
 
   .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Section.findOne({id: req.params.id}, function(err, obj) {
       if (err)
         res.send(err);
@@ -156,6 +172,10 @@ router.route('/v1/sections/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var now = new Date().getTime();
     req.body.section.updatedAt = now;
     Section.findOneAndUpdate({id: req.params.id}, {$set: req.body.section}, function(err,section) {
@@ -178,6 +198,10 @@ router.route('/v1/sections/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Section.remove({id: req.params.id}, function(err, section) {
       if (err)
         res.send(err);

--- a/app/routes/sections.js
+++ b/app/routes/sections.js
@@ -7,7 +7,7 @@ var passport = require('passport');
 
 router.route('/v1/sections')
 
-  .post(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .post(function(req, res) {
     var section = new Section(req.body.section);
     section.save(function (err, obj) {
       if(err) 
@@ -24,7 +24,7 @@ router.route('/v1/sections')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     Section.findOne({psId: req.body.section.psId}, function (err, sct) {
       if (sct) {
         if (sct.expression == req.body.section.expression && sct.studentCount == req.body.section.studentCount 
@@ -72,7 +72,7 @@ router.route('/v1/sections')
     });
   })
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     if(req.user.user_type != "Administrator") {
       res.send(403,JSON.stringify({"error": "insufficientPermission"}));
       return;
@@ -139,7 +139,7 @@ router.route('/v1/sections')
 
 router.route('/v1/sections/:id')
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     if(req.user.user_type != "Administrator") {
       res.send(403,JSON.stringify({"error": "insufficientPermission"}));
       return;
@@ -163,7 +163,7 @@ router.route('/v1/sections/:id')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     var now = new Date().getTime();
     req.body.section.updatedAt = now;
     Section.findOneAndUpdate({id: req.params.id}, {$set: req.body.section}, function(err,section) {
@@ -185,7 +185,7 @@ router.route('/v1/sections/:id')
     });
   })
 
-  .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .delete(function(req, res) {
     Section.remove({id: req.params.id}, function(err, section) {
       if (err)
         res.send(err);

--- a/app/routes/students.js
+++ b/app/routes/students.js
@@ -7,7 +7,7 @@ var passport = require('passport');
 
 router.route('/v1/students')
 
-  .post(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .post(function(req, res) {
     var student = new Student(req.body.student);
     student.save(function (err, obj) {
       if(err) 
@@ -24,7 +24,7 @@ router.route('/v1/students')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     Student.findOne({nameId: req.body.student.nameId}, function (err, stu) {
       if (stu) {
         if (String(stu.studentNumber) == String(req.body.student.studentNumber) && String(stu.firstName) == String(req.body.student.firstName) 
@@ -74,7 +74,7 @@ router.route('/v1/students')
     });
   })
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     var qString = req.query;
     if (qString.ids) {
       var queryOne = Student.find({ id: { $in: qString.ids } });
@@ -135,7 +135,7 @@ router.route('/v1/students')
 
 router.route('/v1/students/:id')
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     Student.findOne({id: req.params.id}, function(err, obj) {
       if (err)
         res.send(err);
@@ -166,7 +166,7 @@ router.route('/v1/students/:id')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     var now = new Date().getTime();
     req.body.student.updatedAt = now;
     Student.findOneAndUpdate({id: req.params.id}, {$set: req.body.student}, function(err,student) {
@@ -188,7 +188,7 @@ router.route('/v1/students/:id')
     });
   })
 
-  .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .delete(function(req, res) {
     Student.remove({id: req.params.id}, function(err, student) {
       if (err)
         res.send(err);

--- a/app/routes/students.js
+++ b/app/routes/students.js
@@ -106,9 +106,15 @@ router.route('/v1/students')
         });
       },
       records: function(callback){
-        queryTwo.skip(offset).select('-_id -__v -salt -hash').limit(limit).exec('find', function(err, items) {
-          callback(null, items);
-        });
+        if(req.user.user_type == "Administrator") { 
+          queryTwo.skip(offset).select('-_id -__v -salt -hash').limit(limit).exec('find', function(err, items) {
+            callback(null, items);
+          });
+        } else {
+          queryTwo.skip(offset).select('-_id id firstName lastName buildingName buildingStateCode username gradeLevel').limit(limit).exec('find', function(err, items) {
+            callback(null, items);
+          });
+        }
       }
     },
     function(err, results) {
@@ -144,6 +150,17 @@ router.route('/v1/students/:id')
       if (obj) {
         obj._id = undefined;
         obj.__v = undefined;
+        if(req.user.user_type != "Administrator") {
+          obj = {
+            id: obj.id,
+            username: obj.username,
+            firstName: obj.firstName,
+            lastName: obj.lastName,
+            buildingName: obj.buildingName,
+            buildingStateCode: obj.buildingStateCode,
+            gradeLevel: obj.gradeLevel
+          };
+        }
         var data = {
           "student": obj,
           "meta": {

--- a/app/routes/students.js
+++ b/app/routes/students.js
@@ -8,6 +8,10 @@ var passport = require('passport');
 router.route('/v1/students')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var student = new Student(req.body.student);
     student.save(function (err, obj) {
       if(err) 
@@ -25,6 +29,10 @@ router.route('/v1/students')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Student.findOne({nameId: req.body.student.nameId}, function (err, stu) {
       if (stu) {
         if (String(stu.studentNumber) == String(req.body.student.studentNumber) && String(stu.firstName) == String(req.body.student.firstName) 
@@ -150,6 +158,10 @@ router.route('/v1/students/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     var now = new Date().getTime();
     req.body.student.updatedAt = now;
     Student.findOneAndUpdate({id: req.params.id}, {$set: req.body.student}, function(err,student) {
@@ -172,6 +184,10 @@ router.route('/v1/students/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+    if(req.user.user_type != "Administrator") {
+      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+      return;
+    }
     Student.remove({id: req.params.id}, function(err, student) {
       if (err)
         res.send(err);

--- a/app/routes/students.js
+++ b/app/routes/students.js
@@ -8,10 +8,6 @@ var passport = require('passport');
 router.route('/v1/students')
 
   .post(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var student = new Student(req.body.student);
     student.save(function (err, obj) {
       if(err) 
@@ -29,10 +25,6 @@ router.route('/v1/students')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Student.findOne({nameId: req.body.student.nameId}, function (err, stu) {
       if (stu) {
         if (String(stu.studentNumber) == String(req.body.student.studentNumber) && String(stu.firstName) == String(req.body.student.firstName) 
@@ -175,10 +167,6 @@ router.route('/v1/students/:id')
   })
 
   .put(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     var now = new Date().getTime();
     req.body.student.updatedAt = now;
     Student.findOneAndUpdate({id: req.params.id}, {$set: req.body.student}, function(err,student) {
@@ -201,10 +189,6 @@ router.route('/v1/students/:id')
   })
 
   .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
-    if(req.user.user_type != "Administrator") {
-      res.send(403,JSON.stringify({"error": "insufficientPermission"}));
-      return;
-    }
     Student.remove({id: req.params.id}, function(err, student) {
       if (err)
         res.send(err);

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -30,7 +30,7 @@ router.route('/v1/users')
     });
   })
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .get(function(req, res) {
     var qString = req.query;
     if (qString.ids) {
       var queryOne = User.find({ id: { $in: qString.ids } });
@@ -81,8 +81,8 @@ router.route('/v1/users')
   })
 
 router.route('/v1/users/:id')
+  .get(function(req, res) {
 
-  .get(passport.authenticate('bearer', { session: false }),function(req, res) {
     User.findOne({id: req.params.id}, function(err, obj) {
       if (err)
         res.send(err);
@@ -102,7 +102,7 @@ router.route('/v1/users/:id')
     });
   })
 
-  .put(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .put(function(req, res) {
     var now = new Date().getTime();
     req.body.user.updatedAt = now;
     User.findOneAndUpdate({id: req.params.id}, {$set: req.body.user}, function(err,user) {
@@ -146,7 +146,7 @@ router.route('/v1/users/:id')
     });
   })
 
-  .delete(passport.authenticate('bearer', { session: false }),function(req, res) {
+  .delete(function(req, res) {
     User.remove({id: req.params.id}, function(err, user) {
       if (err)
         res.send(err);

--- a/index.js
+++ b/index.js
@@ -68,7 +68,6 @@ require('./app/config/passport')(passport);
 app.use('/api', require('./app/routes/auth'));
 
 app.use(passport.authenticate('bearer', { session: false }), function(req, res, next){
-  console.log(req);
   if(req.url != "/v1/api/auth/login") {
     if(req.method == "POST" || req.method == "PUT" || req.method == "DELETE") {
       if(req.user.user_type != "Administrator") {

--- a/index.js
+++ b/index.js
@@ -64,10 +64,25 @@ autoIncrement.initialize(db);
 app.use(passport.initialize());
 require('./app/config/passport')(passport);
 
+//Import the auth plugin before requireing passport middleware
+app.use('/api', require('./app/routes/auth'));
+
+app.use(passport.authenticate('bearer', { session: false }), function(req, res, next){
+  console.log(req);
+  if(req.url != "/v1/api/auth/login") {
+    if(req.method == "POST" || req.method == "PUT" || req.method == "DELETE") {
+      if(req.user.user_type != "Administrator") {
+        res.send(403,JSON.stringify({"error": "insufficientPermission"}));
+        return;
+      }
+    }
+  }
+  next();
+});
+
 // REGISTER ALL THE ROUTES -------------------------------
 // all of our routes will be prefixed with /api
 app.use('/api', require('./app/routes/employees'));
-app.use('/api', require('./app/routes/auth'));
 app.use('/api', require('./app/routes/users'));
 app.use('/api', require('./app/routes/students'));
 app.use('/api', require('./app/routes/sections'));


### PR DESCRIPTION
API users already had a `user_type` in the database/data model. I utilized this to create a basic error message with middleware when trying to use endpoints that require Administrator privileges. 

A new account exists in the database with a `user_type` of "Public", currently no code checks for this `user_type` but instead checks if the `user_type` is "Administrator".