### PR TITLE
Add monitoring for duplicate nameIds

### DIFF
--- a/app/routes/monitoring.js
+++ b/app/routes/monitoring.js
@@ -1,21 +1,54 @@
-const express = require('express')
+const express = require("express");
 const router = express.Router();
-const Employee = require('../models/employees');
+const Employee = require("../models/employees");
 
-router.route('/v1/monitoring/missingUsernames')
-  .get(async (req, res) => {
+// Each monitor is a function that returns an object with a status ("warning"
+// or "ok", a message, and "details" which can be any JSON.
+const monitors = {
+  missingUsernames: async () => {
     const badEmployees = await Employee.find({
-      certNumber: {$exists: true, $nin: [null, '']},
-      $or: [
-        { username: null },
-        { username: '' }
-      ]
-    })
-    if(badEmployees.length > 0) {
-      res.json({status: 'warning', message: `${badEmployees.length} employee(s) have cert numbers but not usernames.`})
+      certNumber: { $exists: true, $nin: [null, ""] },
+      $or: [{ username: null }, { username: "" }]
+    });
+
+    if (badEmployees.length > 0) {
+      return {
+        status: "warning",
+        message: `${badEmployees.length} employee(s) have cert numbers but not usernames.`,
+        details: { employeeIds: badEmployees.map(e => e.id) }
+      };
     } else {
-      res.json({status: 'ok', message: "All employees with cert numbers have usernames."})
+      return {
+        status: "ok",
+        message: "All employees with cert numbers have usernames."
+      };
     }
-  })
+  },
+  duplicateEmployeeNameIds: async () => {
+    const dupes = await Employee.aggregate(
+      { $group: { _id: "$nameId", count: { $sum: 1 } } },
+      { $match: { _id: { $ne: null }, count: { $gt: 1 } } },
+      { $project: { nameId: "$_id", _id: 0 } }
+    );
+    console.log(dupes);
+    return { status: "ok", message: "foo" };
+  }
+};
+
+router.route("/v1/monitoring/:monitor").get(async (req, res) => {
+  const monitor = monitors[req.params.monitor];
+
+  res.json(await monitor());
+});
+
+router.route("/v1/monitoring").get(async (req, res) => {
+  const monitorNames = Object.keys(monitors);
+
+  const pairs = await Promise.all(
+    monitorNames.map(async name => [name, await monitors[name]()])
+  );
+
+  res.json(Object.fromEntries(pairs));
+});
 
 module.exports = router;

--- a/app/routes/monitoring.js
+++ b/app/routes/monitoring.js
@@ -30,8 +30,15 @@ const monitors = {
       { $match: { _id: { $ne: null }, count: { $gt: 1 } } },
       { $project: { nameId: "$_id", _id: 0 } }
     );
-    console.log(dupes);
-    return { status: "ok", message: "foo" };
+    if (dupes.length == 0) {
+      return { status: "ok", message: "No employees have duplicate nameIds." };
+    } else {
+      return {
+        status: "warning",
+        message: `${dupes.length} employee(s) have duplicate nameIds.`,
+        details: { duplicateNameIds: dupes.map(dupe => dupe.nameId) }
+      };
+    }
   }
 };
 


### PR DESCRIPTION
cc @RhettPrichard 

The new endpoint is at `/api/v1/monitoring`. Its output looks like this:

```json
{
    "duplicateEmployeeNameIds": {
        "details": {
            "duplicateNameIds": [
                52
            ]
        },
        "message": "1 employee(s) have duplicate nameIds.",
        "status": "warning"
    },
    "missingUsernames": {
        "message": "All employees with cert numbers have usernames.",
        "status": "ok"
    }
}
```

If you'd prefer to deal with separate monitors individually, there are also `/api/v1/monitoring/duplicateEmployeeNameIds` and `/api/v1/monitoring/missingUsernames` endpoints that behave similarly, just without the outer object.